### PR TITLE
Create new .jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ application {
 }
 
 shadowJar {
-    archiveBaseName = "MitsukiMain"
+    archiveBaseName = "MainMitsuki"
     archiveClassifier = null
     dependsOn("distZip", "distTar")
 }


### PR DESCRIPTION
The current executable .jar file does not include the JavaFX library, and the chatbot will not run properly on computers that do not have JavaFX installed.

Create a new executable .jar file using gradle to allow Mitsuki to be run on computers that do not have JavaFX installed.